### PR TITLE
Fix broken link in suggested markdown

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -73,8 +73,7 @@
 
 <p>Embed with: <b><code>&lt;a href="https://nodei.co/npm-dl/&lt;package&gt;/"&gt;&lt;img src="https://nodei.co/npm-dl/&lt;package&gt;.png"&gt;&lt;/a&gt;</code></b></p>
 
-<p>Or in Markdown: <b><code>[![NPM](https://nodei.co/npm-dl/&lt;package&gt;.png)](https://nodei.co/npm-dl/&lt;package&gt;/)
-</code></b></p>
+<p>Or in Markdown: <b><code>[NPM](https://nodei.co/npm-dl/&lt;package&gt;.png)</code></b></p>
 
 <p><a href="https://nodei.co/npm-dl/xtend.png">https://nodei.co/npm-dl/xtend.png</a></p>
 <a href="https://nodei.co/npm-dl/xtend/"><img src="/npm-dl/xtend.png"></a>


### PR DESCRIPTION
Turns out https://nodei.co/npm-dl/PROJECT/ is a 404 Not Found. No reason for projects to link to it, then.
