### PR TITLE
option to disable npm logo on the downloads badge

### DIFF
--- a/lib/draw-npm-downloads-badge.js
+++ b/lib/draw-npm-downloads-badge.js
@@ -51,11 +51,11 @@ function drawLogo (ctx, margin) {
   ctx.fillText('npm', margin + 7, 1)
 }
 
-function drawTitle (ctx, margin, label) {
+function drawTitle (ctx, titleX, titleY, label) {
   ctx.font = '14px ubuntu-b'
   ctx.fillStyle = 'rgb(102, 102, 102)'
   ctx.textBaseline = 'top'
-  ctx.fillText(label, margin + 106, margin)
+  ctx.fillText(label, titleX, titleY)
 }
 
 function drawUnavailable (ctx, margin, height, width) {
@@ -75,12 +75,12 @@ function dayDownloads (downloads, day) {
   return 0
 }
 
-function drawHistogram (ctx, margin, months, downloads, days, width, height, max, maxText) {
+function drawHistogram (ctx, marginX, marginY, months, downloads, days, width, height, max, maxText) {
   var day   = moment().subtract('months', months)
     , today = moment()
-    , x1    = margin + 106
-    , y1    = margin
-    , y2    = margin + height
+    , x1    = marginX
+    , y1    = marginY
+    , y2    = marginY + height
     , h     = y2 - y1
     , inc   = width / days
     , i     = 0
@@ -109,14 +109,14 @@ function drawHistogram (ctx, margin, months, downloads, days, width, height, max
   ctx.textBaseline = 'top'
   ctx.fillText(
       maxText
-    , margin + 106 + width + 2
-    , margin - 1
+    , marginX + width + 2
+    , marginY - 1
   )
   ctx.textBaseline = 'bottom'
   ctx.fillText(
       '0'
-    , margin + 106 + width + 2
-    , margin + h + 1
+    , marginX + width + 2
+    , marginY + h + 1
   )
 }
 
@@ -125,6 +125,7 @@ function drawHistogram (ctx, margin, months, downloads, days, width, height, max
 function draw (options, pkginfo) {
   var margin       = MARGIN
     , months       = options.downloads
+    , noLogo       = options.noLogo
     , max          = pkginfo.downloadDays
         ? pkginfo.downloadDays.reduce(function (p, c) {
             return Math.max(p, c.count)
@@ -132,9 +133,9 @@ function draw (options, pkginfo) {
         : 0
     , label        = pkginfo.name + ' downloads (' + months + ' month'
         + (months == 1 ? '' : 's') + ')'
-    , labelRight   = margin + 106 + 7 * label.length
+    , labelRight   = margin + (noLogo ? 0 : 106) + 7 * label.length
     , days         = moment().diff(moment().subtract('months', months), 'days')
-    , histRight    = margin + 106 + days
+    , histRight    = margin + (noLogo ? 0 : 106) + days
     , maxText      = humanize(max)
     , maxTextWidth = 6 * maxText.length
     //, maxTextRight = histRight + maxTextWidth
@@ -150,16 +151,17 @@ function draw (options, pkginfo) {
 
   drawInit(ctx)
   drawBox(ctx, margin, INSET, height, width)
-  drawLogo(ctx, margin)
+  if (!noLogo) drawLogo(ctx, margin)
 
   if (pkginfo.downloadDays) {
     drawHistogram(
         ctx
+      , margin + (noLogo ? 0 : 106)
       , margin
       , months
       , pkginfo.downloadDays
       , days
-      , labelRight > margin + 106 + days ? 7 * label.length : days
+      , labelRight > margin + (noLogo ? 0 : 106) + days ? 7 * label.length : days
       , barHeight
       , max
       , maxText
@@ -168,7 +170,7 @@ function draw (options, pkginfo) {
     drawUnavailable(ctx, margin, height, width)
   }
 
-  drawTitle(ctx, margin, label)
+  drawTitle(ctx, margin + (noLogo ? 0 : 106), margin, label)
 
   return canvas
 }

--- a/lib/routes/npm-downloads-badge.js
+++ b/lib/routes/npm-downloads-badge.js
@@ -16,6 +16,10 @@ function handler (req, res, opts, callback) {
           nodepends : true
         , months    : Math.round(qs.months || 12)
         , height    : qs.height > 1 ? parseInt(qs.height, 10) : 1
+        , noLogo : (typeof qs.noLogo !== 'undefined') && (
+            qs.noLogo === '' ||
+            ['0', 'no', 'false'].indexOf(qs.noLogo) < 0
+        )
       }
 
   res.setHeader('cache-control', 'no-cache')


### PR DESCRIPTION
This pull request is inspired by the idea of #11 but implemented for the histogram of downloads instead of the main badge.

These changes are presented in a hope that they're fine, but I haven't actually tested them because [`canvas`](https://www.npmjs.com/package/canvas) doesn't work on Windows and I do not have an immediate access to a Linux box.
