### PR TITLE
Typo in Markdown

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -93,7 +93,7 @@
 
 <p>Embed with: <b><code>&lt;a href="https://nodei.co/npm/&lt;package&gt;/"&gt;&lt;img src="https://nodei.co/npm-dl/&lt;package&gt;.png"&gt;&lt;/a&gt;</code></b></p>
 
-<p>Or in Markdown: <b><code>[![NPM](https://nodei.co/npm/&lt;package&gt;.png)](https://nodei.co/npm-dl/&lt;package&gt;/)
+<p>Or in Markdown: <b><code>[![NPM](https://nodei.co/npm-dl/&lt;package&gt;.png)](https://nodei.co/npm/&lt;package&gt;/)
 </code></b></p>
 
 <p><a href="https://nodei.co/npm-dl/xtend.png">https://nodei.co/npm-dl/xtend.png</a></p>


### PR DESCRIPTION
Image first *then* link location.