### PR TITLE
Move `-g` in preferGlobal packages to after install

### DIFF
--- a/lib/draw-npm-badge.js
+++ b/lib/draw-npm-badge.js
@@ -160,7 +160,7 @@ function downloadRankDescriptor (ranking) {
 
 function calculateParams (options, pkginfo) {
   let margin        = options.mini ? 1 : MARGIN
-    , installName   = `${pkginfo.name}${pkginfo.preferGlobal ? ' -g' : ''}`
+    , installName   = `${pkginfo.preferGlobal ? '-g ' : ''}${pkginfo.name}`
     , versionText   = !!pkginfo.version ? `version ${pkginfo.version}` : ''
     , updatedText   = !!pkginfo.updated ? `updated ${moment(pkginfo.updated).fromNow()}` : ''
     , compactText   = options.compact


### PR DESCRIPTION
That's how it's usually placed in READMEs, looks kinda weird at the end